### PR TITLE
Fixed error: item with href = $filename is missing

### DIFF
--- a/lib/src/readers/navigation_reader.dart
+++ b/lib/src/readers/navigation_reader.dart
@@ -5,6 +5,7 @@ import 'dart:convert' as convert;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:epubx/src/schema/opf/epub_version.dart';
 import 'package:xml/xml.dart' as xml;
+import 'package:path/path.dart' as path;
 
 import '../schema/navigation/epub_metadata.dart';
 import '../schema/navigation/epub_navigation.dart';
@@ -249,7 +250,7 @@ class NavigationReader {
               attributeValue.contains(_tocFileEntryPath!)) {
             result.Source = attributeValue;
           } else {
-            result.Source = _tocFileEntryPath! + attributeValue;
+            result.Source = path.normalize(_tocFileEntryPath! + attributeValue);
           }
 
           break;


### PR DESCRIPTION
Added path normalization
Fixed "Exception: Incorrect EPUB manifest: item with href = $filename is missing."